### PR TITLE
Added a property to shift the Z-axis of the Follow Cam/3D Cursor.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,9 @@
 bl_info = {
     "name" : "libsm64-blender",
     "author" : "libsm64",
-    "description" : "",
+    "description" : "Add a playble Mario to your Blender Scene",
     "blender" : (2, 80, 0),
-    "version" : (0, 0, 1),
+    "version" : (1, 0, 5),
     "location" : "View3D",
     "warning" : "",
     "category" : "Generic"
@@ -24,6 +24,31 @@ class LibSm64Properties(bpy.types.PropertyGroup):
         name="Follow Mario with 3D cursor + camera",
         default=True
     )
+    camera_vert_shift : bpy.props.FloatProperty (
+        name='Camera Vertical Offset', 
+        description='Camera Offset from Mario Origin.', 
+        default=(1.0), 
+        soft_min =-10.0, 
+        soft_max=10.0, 
+        step=10, 
+        precision=3, 
+        subtype='DISTANCE', 
+        unit='LENGTH', 
+    )
+    # FIXME: I couldn't figure out how to pass a FloatVectorProperty into the script, so this is disbled for now. 
+    # The below lines (40 to 51) would replace the camera_vert_shift above, if properly implemented.
+    # camera_vector_test : bpy.props.FloatVectorProperty (
+    #     name='Mario Cam Offset', 
+    #     description='Camera Offset from Mario Origin.', 
+    #     default=(0.0, 0.0, 1.0), 
+    #     soft_min =-10.0, 
+    #     soft_max=10.0, 
+    #     step=10, 
+    #     precision=3,
+    #     subtype='XYZ', 
+    #     unit='LENGTH', 
+    #     size=3
+    # )
     mario_scale : bpy.props.FloatProperty(
         name="Blender to SM64 Scale",
         default=100
@@ -44,7 +69,9 @@ class Main_PT_Panel(bpy.types.Panel):
         prop_split(col, scene.libsm64, "mario_scale", "Blender to SM64 Scale")
         col.label(text="SM64 US ROM (Unmodified, 8 MB, z64)")
         col.prop(scene.libsm64, "rom_path")
+        # col.prop(scene.libsm64, "camera_vector_test") #FIXME
         col.prop(scene.libsm64, "camera_follow")
+        col.prop(scene.libsm64, "camera_vert_shift")
         col.operator(InsertMario_OT_Operator.bl_idname, text='Insert Mario')
         col.operator(ControlMario_OT_Operator.bl_idname, text='Control Mario with keyboard')
         col.label(text="WASD + JKL to move. ESC to stop.")
@@ -56,7 +83,7 @@ class InsertMario_OT_Operator(bpy.types.Operator):
 
     def execute(self, context):
         scene = context.scene
-        err = insert_mario(scene.libsm64.rom_path, scene.libsm64.mario_scale, scene.libsm64.camera_follow)
+        err = insert_mario(scene.libsm64.rom_path, scene.libsm64.mario_scale, scene.libsm64.camera_follow, scene.libsm64.camera_vert_shift)
         if err != None:
             self.report({"ERROR"}, err)
         return {'FINISHED'}
@@ -117,6 +144,7 @@ def process_input(event):
                 input_value[k] = True
             else:
                 input_value[k] = False
+
 
 register_classes, unregister_classes = bpy.utils.register_classes_factory((
     LibSm64Properties,

--- a/mario.py
+++ b/mario.py
@@ -78,8 +78,8 @@ mario_geo = SM64MarioGeometryBuffers()
 follow_cam = False
 tick_count = 0
 
-def insert_mario(rom_path: str, scale: float, camera_follow: bool):
-    global sm64, sm64_mario_id, SM64_SCALE_FACTOR, original_fps, tick_count, origin_offset, original_cursor_pos, follow_cam
+def insert_mario(rom_path: str, scale: float, camera_follow: bool, camera_vert_shift: float):
+    global sm64, sm64_mario_id, SM64_SCALE_FACTOR, original_fps, tick_count, origin_offset, original_cursor_pos, follow_cam, cam_vert
 
     SM64_SCALE_FACTOR = scale
 
@@ -95,6 +95,9 @@ def insert_mario(rom_path: str, scale: float, camera_follow: bool):
         bpy.context.scene.cursor.location.z
     ]
     follow_cam = camera_follow
+    cam_vert = camera_vert_shift
+    # FIXME: Again, I couldn't figure out how to get the vector into the script, so come back to this later.
+    # cam_vec = camera_vector_test
 
     origin_offset[0] = bpy.context.scene.cursor.location.x
     origin_offset[1] = bpy.context.scene.cursor.location.y
@@ -191,9 +194,9 @@ def tick_mario(x0, x1):
 
     if follow_cam:
         bpy.context.scene.cursor.location = (
-             origin_offset[0] + mario_state.posX / SM64_SCALE_FACTOR,
-             origin_offset[1] - mario_state.posZ / SM64_SCALE_FACTOR,
-             origin_offset[2] + mario_state.posY / SM64_SCALE_FACTOR,
+            origin_offset[0] + mario_state.posX / SM64_SCALE_FACTOR,
+            origin_offset[1] - mario_state.posZ / SM64_SCALE_FACTOR,
+            (origin_offset[2] + mario_state.posY / SM64_SCALE_FACTOR) + cam_vert, # Add the vertical cam offset here.
         )
 
         for region in (r for r in view3d.regions if r.type == 'WINDOW'):


### PR DESCRIPTION
This should fix the issue I opened up at: https://github.com/libsm64/libsm64-blender/issues/27

Its just a single float, but it works, and it lets you adjust the vertical center of the Camera to point it more towards Mario's head (or above or below if you want). 

I tried to add an XYZ VectorFloatProperty so you could adjust the X, Y, or Z position of the 3D cursor, but I couldn't figure out how to pass the Vector into the script to be used as a variable.

I left the VectorFloatProperty in the panel code, since that part does work (its just commented out since it currently doesn't do anything).

If anyone can figure it out, feel free to modify the code.