### PR TITLE
Add add-on preferences

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -14,12 +14,6 @@ import platform
 from . mario import insert_mario
 
 class LibSm64Properties(bpy.types.PropertyGroup):
-    rom_path : bpy.props.StringProperty(
-        name="Path",
-        description="Path to an unmodified US SM64 ROM",
-        subtype='FILE_PATH',
-        default=('c:\\sm64.us.z64' if platform.system() == 'Windows' else '~/sm64.us.z64')
-    )
     camera_follow : bpy.props.BoolProperty (
         name="Follow Mario with 3D cursor + camera",
         default=True
@@ -40,6 +34,20 @@ class LibSm64Properties(bpy.types.PropertyGroup):
         name="Blender to SM64 Scale",
         default=100
     )
+    
+class LibSm64Preferences(bpy.types.AddonPreferences):
+    bl_idname = __name__
+    rom_path : bpy.props.StringProperty(
+        name="Path",
+        description="Path to an unmodified US SM64 ROM",
+        subtype='FILE_PATH',
+        default=('c:\\sm64.us.z64' if platform.system() == 'Windows' else '~/sm64.us.z64')
+    )
+    def draw(self, context):
+        layout = self.layout
+        col = layout.column()
+        col.label(text="SM64 US ROM (Unmodified, 8 MB, z64)")
+        col.prop(self, 'rom_path')
 
 class Main_PT_Panel(bpy.types.Panel):
     bl_idname = "LIBSM64_PT_main_panel"
@@ -54,7 +62,6 @@ class Main_PT_Panel(bpy.types.Panel):
 
         col = layout.column()
         prop_split(col, scene.libsm64, "mario_scale", "Blender to SM64 Scale")
-        col.label(text="SM64 US ROM (Unmodified, 8 MB, z64)")
         col.prop(scene.libsm64, "rom_path")
         col.prop(scene.libsm64, "camera_follow")
         col.operator(InsertMario_OT_Operator.bl_idname, text='Insert Mario')
@@ -69,7 +76,8 @@ class InsertMario_OT_Operator(bpy.types.Operator):
 
     def execute(self, context):
         scene = context.scene
-        err = insert_mario(scene.libsm64.rom_path, scene.libsm64.mario_scale, scene.libsm64.camera_follow)
+        preferences = context.preferences.addons[__package__].preferences
+        err = insert_mario(preferences.rom_path, scene.libsm64.mario_scale, scene.libsm64.camera_follow)
         if err != None:
             self.report({"ERROR"}, err)
         return {'FINISHED'}
@@ -134,6 +142,7 @@ def process_input(event):
 
 register_classes, unregister_classes = bpy.utils.register_classes_factory((
     LibSm64Properties,
+    LibSm64Preferences,
     Main_PT_Panel,
     InsertMario_OT_Operator,
     ControlMario_OT_Operator


### PR DESCRIPTION
This change moves the ROM path selection to the add-on's preferences so that it doesn't need to be reset for every new file. 