### PR TITLE
Update __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@ bl_info = {
     "author" : "libsm64",
     "description" : "Add a playble Mario to your Blender Scene",
     "blender" : (2, 80, 0),
-    "version" : (1, 0, 5),
+    "version" : (1, 0, 6),
     "location" : "View3D",
     "warning" : "",
     "category" : "Generic"


### PR DESCRIPTION
Latest release is listed as 1.0.6, but the _init_.py still lists the add-on as version 1.0.5, thus also showing up incorrectly in Blender's add-ons preferences page.

A minor fix, but important nonetheless.

I noticed this when installing Blender 3.6 and going through my add-ons between 2.80 and 3.6.