### PR TITLE
fix camera rotation on windows

### DIFF
--- a/input_reader.py
+++ b/input_reader.py
@@ -31,11 +31,12 @@ JOYSTICK_TRESHOLD = 0.3
 
 def sample_input_reader(mario_inputs):
     from . import config, input_value
-    mario_inputs.camLookX = 0;
-    mario_inputs.camLookZ = 0;
+
     if config['keyboard_control']:
         mario_inputs.stickX = input_value['RIGHT']*1 - input_value['LEFT']*1
         mario_inputs.stickY = input_value['DOWN']*1 - input_value['UP']*1
+        mario_inputs.camLookX = 0.0
+        mario_inputs.camLookZ = 0.0
         mario_inputs.buttonA = input_value['A']
         mario_inputs.buttonB = input_value['B']
         mario_inputs.buttonZ = input_value['C']

--- a/input_reader_win.py
+++ b/input_reader_win.py
@@ -28,6 +28,8 @@ def sample_input_reader(mario_inputs):
     if config['keyboard_control']:
         mario_inputs.stickX = input_value['RIGHT']*1 - input_value['LEFT']*1
         mario_inputs.stickY = input_value['DOWN']*1 - input_value['UP']*1
+        mario_inputs.camLookX = 0.0
+        mario_inputs.camLookZ = 0.0
         mario_inputs.buttonA = input_value['A']
         mario_inputs.buttonB = input_value['B']
         mario_inputs.buttonZ = input_value['C']
@@ -48,9 +50,15 @@ def sample_input_reader(mario_inputs):
         mario_inputs.buttonB = vals[3] != 0
         mario_inputs.buttonZ = vals[4] != 0
 
+        # TODO?
+        mario_inputs.camLookX = 0.0
+        mario_inputs.camLookZ = 0.0
+
 def _sample_empty_inputs(mario_inputs):
     mario_inputs.stickX = 0.0
     mario_inputs.stickY = 0.0
+    mario_inputs.camLookX = 0.0
+    mario_inputs.camLookZ = 0.0
     mario_inputs.buttonA = False
     mario_inputs.buttonB = False
     mario_inputs.buttonZ = False

--- a/mario.py
+++ b/mario.py
@@ -191,15 +191,16 @@ def tick_mario(x0, x1):
     ticks_since_cam_change = tick_count - last_cam_change_tick
     is_cam_change_ok = ticks_since_cam_change > 8
 
-    if is_cam_change_ok and camLookX != 0:  # Dead zone handled in inputs
-        rot_angle = math.radians(360.0 * camLookX)
-        rotation = mathutils.Quaternion((0, 0, 1), rot_angle)
-        r3d.view_rotation = rotation @ r3d.view_rotation
-        last_cam_change_tick = tick_count
-    elif is_cam_change_ok and camLookZ != 0:
-        zoom_factor = 1.0 + camLookZ
-        r3d.view_distance *= zoom_factor
-        last_cam_change_tick = tick_count
+    if is_cam_change_ok:
+        if camLookX != 0:  # Dead zone handled in inputs
+            rot_angle = math.radians(360.0 * camLookX)
+            rotation = mathutils.Quaternion((0, 0, 1), rot_angle)
+            r3d.view_rotation = rotation @ r3d.view_rotation
+            last_cam_change_tick = tick_count
+        elif camLookZ != 0:
+            zoom_factor = 1.0 + camLookZ
+            r3d.view_distance *= zoom_factor
+            last_cam_change_tick = tick_count
 
     look_dir = r3d.view_rotation @ mathutils.Vector((0.0, 0.0, -1.0))
     mario_inputs.camLookX = look_dir.x


### PR DESCRIPTION
it seems camLookX and camLookZ were not reset in input_reader_win.py causing the camera to constantly turn.
they are now correctly reset in every code path.